### PR TITLE
Fix crash without keyWindow

### DIFF
--- a/Sources/NotificationToast/ToastView.swift
+++ b/Sources/NotificationToast/ToastView.swift
@@ -108,7 +108,8 @@ public class ToastView: UIView {
     }
 
     private func getTopViewController() -> UIViewController? {
-        let keyWindow = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
+        let windows = UIApplication.shared.windows
+        let keyWindow = windows.count == 1 ? windows.first : windows.filter { $0.isKeyWindow }.first
         if var topController = keyWindow?.rootViewController {
             while let presentedViewController = topController.presentedViewController {
                 topController = presentedViewController


### PR DESCRIPTION
This fixes the case where no keyWindow is currently found (happened on a fresh empty app).